### PR TITLE
Material Design Makeover

### DIFF
--- a/webpaste.lua
+++ b/webpaste.lua
@@ -85,7 +85,12 @@ return doctype()(
 			.pasteTypeHolder {
 				padding: 4px;
 				color: #fff;
-				display: inline-block;
+				position: absolute;
+				top: 50%;
+				transform: translateY(-50%);
+			}
+			.pasteType {
+				vertical-align: text-top;
 			}
 			textarea {
 				background-color: #111111;
@@ -98,6 +103,7 @@ return doctype()(
 			}
 			#bottom_container {
 				flex-grow: 0;
+				position: relative;
 			}
 			#resultholder {
 				padding: 8px;

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -19,7 +19,7 @@ return doctype()(
 							type: sentType
 						},
 						type: "POST",
-						url: $('#submit').attr('action'),
+						url: $('#submit').attr('formaction'),
 						success: function(response) {
 							$('#resultholder').css({
 								display: "block",
@@ -110,14 +110,17 @@ return doctype()(
 	),
 	tag"body"(
 		tag"textarea"[{name="c", placeholder="Hello World!"}](),
-		tag"button"[{id="submit",action=ret.url}]("Paste!"),
+		tag"button"[{id="submit",formaction=ret.url}]("Paste!"),
 		tag"div"[{class="pasteTypeHolder"}](
-			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio1",checked=""}]("Normal"),
-			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio2"}]("Raw"),
-			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio3"}]("HTML")
+			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio1",checked=""}],
+			tag"label"[{["for"]="radio1"}]("Normal"),
+			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio2"}],
+			tag"label"[{["for"]="radio2"}]("Raw"),
+			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio3"}],
+			tag"label"[{["for"]="radio3"}]("HTML")
 		),
 		tag"div"[{id="resultholder"}](
-			tag"a"[{id="result"}],
+			tag"a"[{id="result"}](""),
 			tag"button"[{id="close"}]("Close")
 		)
 	)

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -34,7 +34,7 @@ return doctype()(
 			});
 		]]),
 		tag"style"[{type="text/css"}]([[
-			html, body, form {
+			body {
 				overflow: hidden;
 				margin: 0px;
 				width: 100%;
@@ -42,59 +42,51 @@ return doctype()(
 				background-color: #010101;
 			}
 			button {
-				padding: 5px;
-				background-color: #111;
-				border: 2px solid #dcdcdc;
+				padding: 8px;
+				background-color: #222;
+				border: none;
+				border-radius: 2px;
 				color: #dcdcdc;
 				text-decoration: none;
 				position: absolute;
-				left: 3px;
-				bottom: 3px;
+				right: 4px;
+				bottom: 4px;
 				transition: 0.2s;
-				-webkit-transition: 0.2s;
-				-moz-transition: 0.2s;
-				-o-transition: 0.2s;
 			}
 			button:hover {
-				background-color: #010101;
+				background-color: #333;
 			}
-			div.pasteTypeHolder {
-				padding: 5px;
-				background-color: #010101;
+			.pasteTypeHolder {
+				padding: 4px;
 				color: #dcdcdc;
 				position: absolute;
-				bottom: 3px;
-				left: 60px;
+				bottom: 4px;
+				left: 4px;
 			}
 			textarea {
 				background-color: #010101;
-				border: 0px;
+				border: none;
 				color: #fff;
 				width: 100%;
+				position: absolute;
 				top: 0px;
 				bottom: 40px;
 				resize: none;
-				position: absolute;
 				outline: 0;
 			}
-			div#resultholder {
-				padding: 5px;
-				background-color: #010101;
-				border: 2px solid #dcdcdc;
+			#resultholder {
+				padding: 8px;
+				background-color: #222;
+				border: none;
+				border-radius: 2px;
 				position: fixed;
 				left: 50%;
 				top: 50%;
-				-webkit-transform: translate( -50%, -50% );
-				-moz-transform: translate( -50%, -50% );
-				-ms-transform: translate( -50%, -50% );
 				transform: translate( -50%, -50% );
 				display: none;
 				transition: 0.2s;
-				-webkit-transition: 0.2s;
-				-moz-transition: 0.2s;
-				-o-transition: 0.2s;
 			}
-			a#result {
+			#result {
 				color: #dcdcdc;
 			}
 		]])

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -51,6 +51,11 @@ return doctype()(
 				height: 100%;
 				background-color: #212121;
 			}
+			#container {
+				display: flex;
+				flex-direction: column;
+				height: 100vh;
+			}
 			button {
 				margin: 4px;
 				padding: 8px;
@@ -68,9 +73,7 @@ return doctype()(
 				background-color: #757575;
 			}
 			#submit {
-				position: absolute;
-				right: 0px;
-				bottom: 0px;
+				float: right;
 				background-color: #311B92;
 			}
 			#submit:hover {
@@ -82,20 +85,19 @@ return doctype()(
 			.pasteTypeHolder {
 				padding: 4px;
 				color: #fff;
-				position: absolute;
-				bottom: 4px;
-				left: 4px;
+				display: inline-block;
 			}
 			textarea {
 				background-color: #111111;
 				border: none;
 				color: #fff;
 				width: 100%;
-				position: absolute;
-				top: 0px;
-				height: calc(100% - 40px);
+				flex-grow: 1;
 				resize: none;
 				outline: 0;
+			}
+			#bottom_container {
+				flex-grow: 0;
 			}
 			#resultholder {
 				padding: 8px;
@@ -116,15 +118,19 @@ return doctype()(
 		]])
 	),
 	tag"body"(
-		tag"textarea"[{name="c", placeholder="Hello World!"}](),
-		tag"button"[{id="submit",formaction=ret.url}]("Paste!"),
-		tag"div"[{class="pasteTypeHolder"}](
-			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio1",checked=""}],
-			tag"label"[{["for"]="radio1"}]("Normal"),
-			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio2"}],
-			tag"label"[{["for"]="radio2"}]("Raw"),
-			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio3"}],
-			tag"label"[{["for"]="radio3"}]("HTML")
+		tag"div"[{id="container"}](
+			tag"textarea"[{name="c", placeholder="Hello World!"}](),
+			tag"div"[{id="bottom_container"}](
+				tag"button"[{id="submit",formaction=ret.url}]("Paste!"),
+				tag"div"[{class="pasteTypeHolder"}](
+					tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio1",checked=""}],
+					tag"label"[{["for"]="radio1"}]("Normal"),
+					tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio2"}],
+					tag"label"[{["for"]="radio2"}]("Raw"),
+					tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio3"}],
+					tag"label"[{["for"]="radio3"}]("HTML")
+				)
+			)
 		),
 		tag"div"[{id="resultholder"}](
 			tag"a"[{id="result"}](""),

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -71,6 +71,13 @@ return doctype()(
 				position: absolute;
 				right: 0px;
 				bottom: 0px;
+				background-color: #311B92;
+			}
+			#submit:hover {
+				background-color: #4527A0;
+			}
+			#submit:active {
+				background-color: #512DA8;
 			}
 			.pasteTypeHolder {
 				padding: 4px;

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -87,7 +87,7 @@ return doctype()(
 				left: 4px;
 			}
 			textarea {
-				background-color: #212121;
+				background-color: #111111;
 				border: none;
 				color: #fff;
 				width: 100%;

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -32,6 +32,15 @@ return doctype()(
 					});
 					return false
 				});
+				
+				$('#close').click(function() {
+					$('#resultholder').css({
+						opacity: "0"
+					});
+					setTimeout(function() {
+						$('#resultholder').css("display","");
+					}, 200 /*ms*/);
+				});
 			});
 		]]),
 		tag"style"[{type="text/css"}]([[
@@ -108,7 +117,8 @@ return doctype()(
 			tag"input"[{type="radio",class="pasteType",name="pasteType",id="radio3"}]("HTML")
 		),
 		tag"div"[{id="resultholder"}](
-			tag"a"[{id="result"}]
+			tag"a"[{id="result"}],
+			tag"button"[{id="close"}]("Close")
 		)
 	)
 ):render()

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -43,6 +43,7 @@ return doctype()(
 				background-color: #010101;
 			}
 			button {
+				margin: 4px;
 				padding: 8px;
 				background-color: #222;
 				border: none;
@@ -59,8 +60,8 @@ return doctype()(
 			}
 			#submit {
 				position: absolute;
-				right: 4px;
-				bottom: 4px;
+				right: 0px;
+				bottom: 0px;
 			}
 			.pasteTypeHolder {
 				padding: 4px;

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -49,9 +49,6 @@ return doctype()(
 				border-radius: 2px;
 				color: #dcdcdc;
 				text-decoration: none;
-				position: absolute;
-				right: 4px;
-				bottom: 4px;
 				transition: 0.2s;
 			}
 			button:hover {
@@ -59,6 +56,11 @@ return doctype()(
 			}
 			button:active {
 				background-color: #666;
+			}
+			#submit {
+				position: absolute;
+				right: 4px;
+				bottom: 4px;
 			}
 			.pasteTypeHolder {
 				padding: 4px;

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -93,7 +93,7 @@ return doctype()(
 				width: 100%;
 				position: absolute;
 				top: 0px;
-				bottom: 40px;
+				height: calc(100% - 40px);
 				resize: none;
 				outline: 0;
 			}

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -22,7 +22,8 @@ return doctype()(
 						url: $('#submit').attr('action'),
 						success: function(response) {
 							$('#resultholder').css({
-								display: "block"
+								display: "block",
+								opacity: "1"
 							});
 							$('#result').html(response);
 							$('#result').attr("href", response);
@@ -87,6 +88,7 @@ return doctype()(
 				top: 50%;
 				transform: translate( -50%, -50% );
 				display: none;
+				opacity: 0;
 				transition: 0.2s;
 			}
 			#result {

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -56,6 +56,9 @@ return doctype()(
 			button:hover {
 				background-color: #333;
 			}
+			button:active {
+				background-color: #666;
+			}
 			.pasteTypeHolder {
 				padding: 4px;
 				color: #dcdcdc;

--- a/webpaste.lua
+++ b/webpaste.lua
@@ -49,23 +49,23 @@ return doctype()(
 				margin: 0px;
 				width: 100%;
 				height: 100%;
-				background-color: #010101;
+				background-color: #212121;
 			}
 			button {
 				margin: 4px;
 				padding: 8px;
-				background-color: #222;
+				background-color: #424242;
 				border: none;
 				border-radius: 2px;
-				color: #dcdcdc;
+				color: #fff;
 				text-decoration: none;
 				transition: 0.2s;
 			}
 			button:hover {
-				background-color: #333;
+				background-color: #616161;
 			}
 			button:active {
-				background-color: #666;
+				background-color: #757575;
 			}
 			#submit {
 				position: absolute;
@@ -74,13 +74,13 @@ return doctype()(
 			}
 			.pasteTypeHolder {
 				padding: 4px;
-				color: #dcdcdc;
+				color: #fff;
 				position: absolute;
 				bottom: 4px;
 				left: 4px;
 			}
 			textarea {
-				background-color: #010101;
+				background-color: #212121;
 				border: none;
 				color: #fff;
 				width: 100%;
@@ -92,7 +92,7 @@ return doctype()(
 			}
 			#resultholder {
 				padding: 8px;
-				background-color: #222;
+				background-color: #424242;
 				border: none;
 				border-radius: 2px;
 				position: fixed;
@@ -104,7 +104,7 @@ return doctype()(
 				transition: 0.2s;
 			}
 			#result {
-				color: #dcdcdc;
+				color: #fff;
 			}
 		]])
 	),


### PR DESCRIPTION
- [x] Partial Material Design page reformatting
- [ ] Primary and Accent colors, pick from [The Material Design Color Palettes please](www.google.com/design/spec/style/color.html#color-ui-color-palette)
- [ ] Animations(ish)

All this absolute positioning nonsense is getting to me :(

List of changes:
Only body should be styled with the background color. html cannot be styled, and giving other elements the same background color only makes the browser's renderer draw more pixels over pixels that it doesn't need.

Moved the submit button to the right of the page. If you look at most websites, the submit buttons are to the right, and configuration is to the left.

wewladdy, those borders are literally Satan. I gave them a little border-radius: 2px; treatment.
# powerof4paddings5lyfe

Many of these prefixed transforms and transitions don't need to exist because transforms and transitions were officially merged into HTML5, making the vendor prefixes a thing of the past. Unless someone is browsing to cpaste on an age old browser (which is already not recomemded by Google), we shouldn't worry about all this vendor prefix replication.

Last, but not least, I removed the child specific selectors. Most to all of the times, web browsers will cache a list of existing ids (since there is only one element with a single id on a page at all times), so when you ask for an id under a certain parent, it will search for all of those parents first, then for the id, instead of looking into the id list for the id that already exists. Since this a relatively simple page, that amount of complexity isn't really needed either.
